### PR TITLE
Nico/eng 2799 fix erlcass segfault 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,14 @@
 /.editorconfig
 /DerivedData/
 /cppcheck_results.xml
+/all_runs.html
+/index.html
+/suite.log.latest.html
+/ct_default.css
+/jquery-latest.js
+/jquery.tablesorter.min.js
+/ct_log_cache
+/ct_run.*
+/variables-ct@*
+/log_manual/
+/erl_crash.dump

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,0 @@
-elixir 1.15.4-otp-26
-erlang 26.0.2
-protoc 3.20.2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+Erlang sources live in `src/`, with shared headers in `include/`. Native C++ NIF code and build scripts sit in `c_src/`, and compiled artifacts land under `_build/`. Common Test suites and configs reside in `test/` (for example `integrity_test_SUITE.erl`), while Cassandra benchmarks and configs are in `benchmarks/`. Runtime assets such as shared libraries are staged in `priv/`. Keep generated logs in `log/` out of version control.
+
+## Build, Test, and Development Commands
+Use `make compile` (default) or `rebar3 compile` to build Erlang modules; both invoke the `rebar3` pipeline and will regenerate `c_src/env.mk` automatically. Run native driver builds with `make nif_compile` and clean them with `make nif_clean`. Execute the Common Test suite via `make ct`, which wraps `ct_run` with the correct `_build` paths and `test/sys.config`. For high-load validation, run `make setup_benchmark` once, then `make benchmark MODULE=erlcass PROCS=100 REQ=100000`.
+
+## Coding Style & Naming Conventions
+Follow OTP-style indentation (four spaces) and prefer snake_case for modules, functions, and variables (`erlcass_session`). Export only what is needed; `rebar.config` enforces `warnings_as_errors` and flags full exports, so clear Dialyzer and compiler warnings before pushing. Macro names stay upper snake case (`?CASS_LOG_WARN`). For C++ code in `c_src/`, keep includes sorted and run `make cpplint` or `make cppcheck` when touching native sources.
+
+## Testing Guidelines
+Add or update Common Test suites named `*_SUITE.erl`, grouping related cases with descriptive test case names such as `reconnect_after_network_drop/1`. Place shared fixtures in `test/sys.config` or helper modules in `src/`. Run `rebar3 as test ct` locally before opening a PR; ensure new behaviour is covered and that `log/` remains clean after a run.
+
+## Native Driver & Security Notes
+`build_deps.sh` fetches the DataStax C++ driver revision pinned in the Makefile; verify checksums when bumping `CPP_DRIVER_REV`. Avoid committing credentials—use environment variables or `test/sys.config` overrides when sharing cluster settings. For production builds, confirm OpenSSL paths in `cppcheck` arguments align with your target hosts.

--- a/c_src/constants.cc
+++ b/c_src/constants.cc
@@ -14,6 +14,7 @@ const char kBindFailedUnknownColumnType[] = "bind failed. not implemented column
 const char kFailedToSetUnknownType[] = "failed to set unknown type";
 const char kUnknownKeyspace[] = "keyspace doesn't exist";
 const char kUnknownTable[] = "table doesn't exist";
+const char kNoConnectionsAvailableMsg[] = "no Cassandra connections available";
 
 // misc atoms
 

--- a/c_src/constants.h
+++ b/c_src/constants.h
@@ -15,6 +15,7 @@ extern const char kBindFailedUnknownColumnType[];
 extern const char kFailedToSetUnknownType[];
 extern const char kUnknownKeyspace[];
 extern const char kUnknownTable[];
+extern const char kNoConnectionsAvailableMsg[];
 
 // misc atoms
 

--- a/test/no_connection_prepare_SUITE.erl
+++ b/test/no_connection_prepare_SUITE.erl
@@ -6,54 +6,13 @@
 -compile(export_all).
 
 all() ->
-    [prepare_statement_without_connection].
+    [prepare_statement_without_session_connections].
 
 suite() ->
-    [{timetrap, {seconds, 30}}].
+    [{timetrap, {seconds, 10}}].
 
-init_per_suite(Config) ->
-    Backup =
-        case application:get_env(erlcass, cluster_options) of
-            undefined ->
-                undefined;
-            Value ->
-                Value
-        end,
-    [{cluster_options_backup, Backup} | Config].
-
-end_per_suite(Config) ->
-    catch application:stop(erlcass),
-    case proplists:get_value(cluster_options_backup, Config) of
-        undefined ->
-            application:unset_env(erlcass, cluster_options);
-        Original ->
-            application:set_env(erlcass, cluster_options, Original)
-    end,
-    _ = application:start(erlcass),
-    ok.
-
-init_per_testcase(_TestCase, Config) ->
-    catch application:stop(erlcass),
-    application:set_env(erlcass, cluster_options, [
-        {contact_points, <<"203.0.113.1">>},
-        {connect_timeout, 1000},
-        {request_timeout, 1000}
-    ]),
-    case application:start(erlcass) of
-        ok ->
-            ok;
-        {error, {already_started, erlcass}} ->
-            ok;
-        Error ->
-            ct:fail({failed_to_start_with_unreachable_contact_points, Error})
-    end,
-    Config.
-
-end_per_testcase(_TestCase, _Config) ->
-    catch application:stop(erlcass),
-    ok.
-
-prepare_statement_without_connection(_Config) ->
-    ct:comment("Attempting to prepare while no Cassandra connections are available"),
-    Result = erlcass:add_prepare_statement(no_connection_stmt, <<"SELECT now() FROM system.local">>),
+prepare_statement_without_session_connections(_Config) ->
+    {ok, Session} = erlcass_nif:cass_session_new(),
+    Tag = make_ref(),
+    Result = erlcass_nif:cass_session_prepare(Session, self(), {<<"SELECT now() FROM system.local">>, []}, Tag),
     ?assertMatch({error, _}, Result).

--- a/test/no_connection_prepare_SUITE.erl
+++ b/test/no_connection_prepare_SUITE.erl
@@ -1,0 +1,59 @@
+-module(no_connection_prepare_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-compile(export_all).
+
+all() ->
+    [prepare_statement_without_connection].
+
+suite() ->
+    [{timetrap, {seconds, 30}}].
+
+init_per_suite(Config) ->
+    Backup =
+        case application:get_env(erlcass, cluster_options) of
+            undefined ->
+                undefined;
+            Value ->
+                Value
+        end,
+    [{cluster_options_backup, Backup} | Config].
+
+end_per_suite(Config) ->
+    catch application:stop(erlcass),
+    case proplists:get_value(cluster_options_backup, Config) of
+        undefined ->
+            application:unset_env(erlcass, cluster_options);
+        Original ->
+            application:set_env(erlcass, cluster_options, Original)
+    end,
+    _ = application:start(erlcass),
+    ok.
+
+init_per_testcase(_TestCase, Config) ->
+    catch application:stop(erlcass),
+    application:set_env(erlcass, cluster_options, [
+        {contact_points, <<"203.0.113.1">>},
+        {connect_timeout, 1000},
+        {request_timeout, 1000}
+    ]),
+    case application:start(erlcass) of
+        ok ->
+            ok;
+        {error, {already_started, erlcass}} ->
+            ok;
+        Error ->
+            ct:fail({failed_to_start_with_unreachable_contact_points, Error})
+    end,
+    Config.
+
+end_per_testcase(_TestCase, _Config) ->
+    catch application:stop(erlcass),
+    ok.
+
+prepare_statement_without_connection(_Config) ->
+    ct:comment("Attempting to prepare while no Cassandra connections are available"),
+    Result = erlcass:add_prepare_statement(no_connection_stmt, <<"SELECT now() FROM system.local">>),
+    ?assertMatch({error, _}, Result).


### PR DESCRIPTION
Do not segfault when scylla is down completely (cannot connect) or it is up but the keyspace does not exist

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Track session connection state and return errors (not crashes) for prepares when no connections; tighten callback/error handling and update Erlang server flow, with a new test.
> 
> - **Native NIF (C++)**:
>   - Add `std::atomic<bool> connected` to `enif_cass_session`; set/reset in `on_session_connect`/`on_session_closed`.
>   - `cass_session_prepare` now checks `connected` and returns `{error, "no Cassandra connections available"}` when disconnected.
>   - Safer resource lifecycle: placement-new/explicit destructor for `enif_cass_session`; free callbacks on error; handle NULL futures.
>   - Wire session resource into callbacks for state updates; improved error-path cleanup for connect/close/prepare.
>   - Add new error constant `kNoConnectionsAvailableMsg`.
> - **Erlang server (`src/erlcass.erl`)**:
>   - `add_prepare_statement/2` immediately replies with error if prepare call fails.
>   - `session_create/0` handles connect failure by closing the session and returning `{error, {session_connect_failed, Error}}`.
> - **Tests**:
>   - Add `test/no_connection_prepare_SUITE.erl` to assert prepare returns `{error, _}` when no session connections.
> - **Docs/Meta**:
>   - Add `AGENTS.md` guidelines; update `.gitignore` entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25bd51a5ca70f17fb2f8bfd847c71f9e07a28a01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->